### PR TITLE
fix: fallback to use ast when fields are defined as a dictionary in custom code

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* PAPP-36740: Fallback to use ast in create and update ticket when SOAR passes the fields param as a stringified dicts with single quotes (happens when fields is defined as a dictionary in custom code)

--- a/servicenow_connector.py
+++ b/servicenow_connector.py
@@ -653,16 +653,18 @@ class ServicenowConnector(BaseConnector):
 
         try:
             fields = json.loads(fields)
-        except json.JSONDecodeError as e:
-            error_message = str(e)
-            return RetVal(
-                action_result.set_status(
-                    phantom.APP_ERROR,
-                    f"Error building fields dictionary: {error_message}. \
-                        Please ensure that provided input is in valid JSON format",
-                ),
-                None,
-            )
+        except json.JSONDecodeError:
+            # Fallback: Try Python literal eval (handles SOAR's stringified dicts with single quotes)
+            try:
+                fields = ast.literal_eval(fields)
+            except (ValueError, SyntaxError) as e:
+                return RetVal(
+                    action_result.set_status(
+                        phantom.APP_ERROR,
+                        f"Error parsing fields: {e!s}. Expected valid JSON or dict format",
+                    ),
+                    None,
+                )
 
         if not isinstance(fields, dict):
             return RetVal(action_result.set_status(phantom.APP_ERROR, SERVICENOW_ERROR_FIELDS_JSON_PARSE), None)
@@ -838,16 +840,18 @@ class ServicenowConnector(BaseConnector):
 
         try:
             fields = json.loads(fields)
-        except json.JSONDecodeError as e:
-            error_message = str(e)
-            return RetVal(
-                action_result.set_status(
-                    phantom.APP_ERROR,
-                    f"Error building fields dictionary: {error_message}. \
-                        Please ensure that provided input is in valid JSON format",
-                ),
-                None,
-            )
+        except json.JSONDecodeError:
+            # Fallback: Try Python literal eval (handles SOAR's stringified dicts with single quotes)
+            try:
+                fields = ast.literal_eval(fields)
+            except (ValueError, SyntaxError) as e:
+                return RetVal(
+                    action_result.set_status(
+                        phantom.APP_ERROR,
+                        f"Error parsing fields: {e!s}. Expected valid JSON or dict format",
+                    ),
+                    None,
+                )
 
         if not isinstance(fields, dict):
             return RetVal(action_result.set_status(phantom.APP_ERROR, SERVICENOW_ERROR_FIELDS_JSON_PARSE), None)


### PR DESCRIPTION
### Features
<!-- Delete this section if your PR does not add any features -->
List any features you're adding to this app (e.g. new actions, parameters, auth methods, etc.)

-

### Bug Fixes
<!-- Delete this section if your PR does not fix any bugs -->
Describe any bugs you've fixed in this app, and how they were fixed

- Addresses: https://splunk.atlassian.net/browse/PAPP-36740. Problem was that when a user writes custom code and passes a dictionary as a field SOAR simply stringifys the dict with single quotes. This causes json.loads() to fail
- Test playbook: https://10.1.19.159/playbook/1487

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [ ] I have verified that manual documentation has been updated where appropriate

### Other information
<!-- Delete this entire section if unused -->
<!-- Please add any other pertinent information you would like reviewers to know about your change -->

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
